### PR TITLE
Implement basic command autofill suggestion in CommandBox

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandHints.java
+++ b/src/main/java/seedu/address/logic/commands/CommandHints.java
@@ -1,0 +1,13 @@
+package seedu.address.logic.commands;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class CommandHints {
+    private CommandHints() {}
+
+    public static final List<String> COMMANDS = Arrays.asList(
+        "add", "edit", "delete", "clear", "find", "list",
+        "help", "exit", "addProfilePic"
+    );
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -4,8 +4,15 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.geometry.Side;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.CustomMenuItem;
+import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.logic.commands.CommandHints;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -26,6 +33,9 @@ public class CommandBox extends UiPart<Region> {
             Path.of(System.getProperty("user.home"), ".command_history")
     );
 
+    private final ContextMenu suggestions = new ContextMenu();
+    private int highlightIndex = -1;
+
     @FXML
     private TextField commandTextField;
 
@@ -39,6 +49,18 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
 
         commandTextField.setOnKeyPressed(this::handleHistoryKeys);
+
+        commandTextField.textProperty().addListener((obs, oldText, newText) -> {
+            updateSuggestions(newText.trim());
+        });
+
+        // Keyboard handling (Tab to accept, Up/Down to navigate, Esc to close)
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPressed);
+
+        // Hide suggestions when focus leaves
+        commandTextField.focusedProperty().addListener((o, was, isNow) -> {
+            if (!isNow) suggestions.hide();
+        });
     }
 
     private void handleHistoryKeys(javafx.scene.input.KeyEvent ev) {
@@ -107,6 +129,98 @@ public class CommandBox extends UiPart<Region> {
         }
 
         styleClass.add(ERROR_STYLE_CLASS);
+    }
+
+    private void updateSuggestions(String prefix) {
+        if (prefix.isEmpty()) {
+            suggestions.hide();
+            return;
+        }
+        var matches = CommandHints.COMMANDS.stream()
+                .filter(cmd -> cmd.startsWith(prefix.toLowerCase()))
+                .limit(8)
+                .toList();
+        if (matches.isEmpty()) {
+            suggestions.hide();
+            return;
+        }
+        suggestions.getItems().clear();
+        highlightIndex = -1;
+        for (int i = 0; i < matches.size(); i++) {
+            final int index = i;
+            String text = matches.get(i);
+
+            Label label = new Label(text);
+            label.setMaxWidth(Double.MAX_VALUE);
+            var item = new CustomMenuItem(label, true);
+
+            item.setOnAction(e -> acceptSuggestion(text));
+            label.setOnMouseEntered(e -> setHighlight(index));
+            suggestions.getItems().add(item);
+        }
+        if (!suggestions.isShowing()) {
+            suggestions.show(commandTextField, Side.BOTTOM, 0, 0);
+        }
+    }
+
+    private void acceptSuggestion(String suggestion) {
+        commandTextField.setText(suggestion + " ");
+        commandTextField.positionCaret(commandTextField.getText().length());
+        suggestions.hide();
+    }
+
+
+    private void setHighlight(int newIndex) {
+        int size = suggestions.getItems().size();
+
+        if (highlightIndex >= 0 && highlightIndex < size) {
+            CustomMenuItem prevItem = (CustomMenuItem) suggestions.getItems().get(highlightIndex);
+            prevItem.getContent().setStyle("");
+        }
+
+        highlightIndex = newIndex;
+
+        if (highlightIndex >= 0 && highlightIndex < size) {
+            CustomMenuItem currItem = (CustomMenuItem) suggestions.getItems().get(highlightIndex);
+            currItem.getContent().setStyle("-fx-font-weight: bold;");
+        }
+    }
+
+    private void handleKeyPressed(KeyEvent e) {
+        if (!suggestions.isShowing() || suggestions.getItems().isEmpty()) {
+            if (e.getCode() == KeyCode.TAB) {
+                e.consume();
+            }
+            return;
+        }
+
+        switch (e.getCode()) {
+        case TAB:
+        case ENTER:
+            e.consume();
+            if (highlightIndex < 0) {
+                setHighlight(0);
+            }
+            String chosen = ((Label) ((CustomMenuItem) suggestions.getItems().get(highlightIndex)).getContent())
+                    .getText();
+            acceptSuggestion(chosen);
+            break;
+        case DOWN:
+            e.consume();
+            int next = (highlightIndex + 1) % suggestions.getItems().size();
+            setHighlight(next);
+            break;
+        case UP:
+            e.consume();
+            int prev = (highlightIndex - 1 + suggestions.getItems().size()) % suggestions.getItems().size();
+            setHighlight(prev);
+            break;
+        case ESCAPE:
+            e.consume();
+            suggestions.hide();
+            break;
+        default:
+        }
     }
 
     /**


### PR DESCRIPTION
CommandBox  requires users to type entire command words manually, which slows down input and increases the chance of typos.

Let's:
- Introduce an autofill feature that suggests matching commands as the user types, displayed in a ContextMenu below the command field.
- Allow users to navigate suggestions with arrow keys and press Tab or Enter to accept a highlighted command.
- Use a ContextMenu-based approach to leverage JavaFX’s built-in UI components, keeping the feature lightweight and integrated with existing CommandBox logic.

This sets the foundation for richer autocomplete features such as command usage hints and argument prefix suggestions.