### PR TITLE
Implement basic command autofill suggestion in CommandBox

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandHints.java
+++ b/src/main/java/seedu/address/logic/commands/CommandHints.java
@@ -3,9 +3,11 @@ package seedu.address.logic.commands;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * List of all command words used for autocomplete and help.
+ * Keep this consistent with each command class's COMMAND_WORD.
+ */
 public final class CommandHints {
-    private CommandHints() {}
-
     public static final List<String> COMMANDS = Arrays.asList(
         "add", "edit", "delete", "clear", "find", "list",
         "help", "exit", "addProfilePic"

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -54,12 +54,12 @@ public class CommandBox extends UiPart<Region> {
             updateSuggestions(newText.trim());
         });
 
-        // Keyboard handling (Tab to accept, Up/Down to navigate, Esc to close)
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPressed);
 
-        // Hide suggestions when focus leaves
         commandTextField.focusedProperty().addListener((o, was, isNow) -> {
-            if (!isNow) suggestions.hide();
+            if (!isNow) {
+                suggestions.hide();
+            }
         });
     }
 


### PR DESCRIPTION
CommandBox requires users to type entire command words manually, which slows down input and increases the chance of typos.

Let's:
- Introduce an autofill feature that suggests matching commands as the user types, displayed in a ContextMenu below the command field.
- Allow users to navigate suggestions with arrow keys and press Tab or Enter to accept a highlighted command.
- Use a ContextMenu-based approach to leverage JavaFX’s built-in UI components, keeping the feature lightweight and integrated with existing CommandBox logic.

This sets the foundation for richer autocomplete features such as command usage hints and argument prefix suggestions.